### PR TITLE
Android Pie version "9" throws exception

### DIFF
--- a/InstaSharper/Classes/DeviceInfo/AndroidVersion.cs
+++ b/InstaSharper/Classes/DeviceInfo/AndroidVersion.cs
@@ -104,15 +104,18 @@ namespace InstaSharper.Classes.DeviceInfo
 
         public static AndroidVersion FromString(string versionString)
         {
-            var version = new Version(versionString);
+            var version = new Version(AppendMinor(versionString));
             foreach (var androidVersion in AndroidVersions)
-                if (version.CompareTo(new Version(androidVersion.VersionNumber)) == 0 ||
-                    version.CompareTo(new Version(androidVersion.VersionNumber)) > 0 &&
+            {
+                if (version.CompareTo(new Version(AppendMinor(androidVersion.VersionNumber))) == 0 ||
                     androidVersion != AndroidVersions.Last() &&
-                    version.CompareTo(new Version(AndroidVersions[AndroidVersions.IndexOf(androidVersion) + 1]
-                        .VersionNumber)) < 0)
+                    version.CompareTo(new Version(AppendMinor(androidVersion.VersionNumber))) > 0 &&
+                    version.CompareTo(new Version(AppendMinor(AndroidVersions[AndroidVersions.IndexOf(androidVersion) + 1].VersionNumber))) < 0)
                     return androidVersion;
+        }
             return null;
         }
+        private static string AppendMinor(string version)
+            => version.Contains(".") ? version : version + ".0";
     }
 }

--- a/InstaSharper/Classes/Models/Media/InstaMedia.cs
+++ b/InstaSharper/Classes/Models/Media/InstaMedia.cs
@@ -42,8 +42,8 @@ namespace InstaSharper.Classes.Models.Media
 
         public InstaCaption Caption { get; set; }
 
-        private string _cmcount;
-        public string CommentsCount { get => _cmcount; set { _cmcount = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("CommentsCount")); } }
+        private int _cmcount;
+        public int CommentsCount { get => _cmcount; set { _cmcount = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("CommentsCount")); } }
 
         public bool IsCommentsDisabled { get; set; }
 

--- a/InstaSharper/Converters/Media/InstaMediaAlbumConverter.cs
+++ b/InstaSharper/Converters/Media/InstaMediaAlbumConverter.cs
@@ -19,7 +19,7 @@ namespace InstaSharper.Converters.Media
                 Code = SourceObject.Media.Code,
                 Pk = SourceObject.Media.Pk,
                 ClientCacheKey = SourceObject.Media.ClientCacheKey,
-                CommentsCount = SourceObject.Media.CommentsCount,
+                CommentsCount = int.TryParse(SourceObject.Media.CommentsCount, out var r) ? r : -1,
                 DeviceTimeStamp = DateTimeHelper.UnixTimestampToDateTime(SourceObject.Media.DeviceTimeStampUnixLike),
                 HasLiked = SourceObject.Media.HasLiked,
                 PhotoOfYou = SourceObject.Media.PhotoOfYou,

--- a/InstaSharper/Converters/Media/InstaMediaConverter.cs
+++ b/InstaSharper/Converters/Media/InstaMediaConverter.cs
@@ -19,7 +19,7 @@ namespace InstaSharper.Converters.Media
                 Code = SourceObject.Code,
                 Pk = SourceObject.Pk,
                 ClientCacheKey = SourceObject.ClientCacheKey,
-                CommentsCount = SourceObject.CommentsCount,
+                CommentsCount = int.TryParse(SourceObject.CommentsCount, out var r) ? r : -1,
                 HasLiked = SourceObject.HasLiked,
                 PhotoOfYou = SourceObject.PhotoOfYou,
                 TrackingToken = SourceObject.TrackingToken,


### PR DESCRIPTION
Version class ctor can't accept only major version string like "9" in case of Android Pie, it requires at least 2 positions like "9.0". 
This is a rather dirty fix but I can't see anything less intrusive for current logic