### PR TITLE
Android Pie version "9" throws an exception

### DIFF
--- a/InstaSharper/Classes/DeviceInfo/AndroidVersion.cs
+++ b/InstaSharper/Classes/DeviceInfo/AndroidVersion.cs
@@ -104,15 +104,18 @@ namespace InstaSharper.Classes.DeviceInfo
 
         public static AndroidVersion FromString(string versionString)
         {
-            var version = new Version(versionString);
+            var version = new Version(AppendMinor(versionString));
             foreach (var androidVersion in AndroidVersions)
-                if (version.CompareTo(new Version(androidVersion.VersionNumber)) == 0 ||
-                    version.CompareTo(new Version(androidVersion.VersionNumber)) > 0 &&
+            {
+                if (version.CompareTo(new Version(AppendMinor(androidVersion.VersionNumber))) == 0 ||
                     androidVersion != AndroidVersions.Last() &&
-                    version.CompareTo(new Version(AndroidVersions[AndroidVersions.IndexOf(androidVersion) + 1]
-                        .VersionNumber)) < 0)
+                    version.CompareTo(new Version(AppendMinor(androidVersion.VersionNumber))) > 0 &&
+                    version.CompareTo(new Version(AppendMinor(AndroidVersions[AndroidVersions.IndexOf(androidVersion) + 1].VersionNumber))) < 0)
                     return androidVersion;
+        }
             return null;
         }
+        private static string AppendMinor(string version)
+            => version.Contains(".") ? version : version + ".0";
     }
 }


### PR DESCRIPTION
Version class ctor can't accept only major version string like "9" in case of Android Pie, it requires at least 2 positions like "9.0".
This is a rather dirty fix but I can't see anything less intrusive for current logic